### PR TITLE
Mention of Atom or Pid in function cuneiform:reduce/5

### DIFF
--- a/src/cf_cre.erl
+++ b/src/cf_cre.erl
@@ -250,12 +250,12 @@ when is_atom( Mod ), is_map( LibMap ) ->
 
 
 -spec submit( Runtime, App, Cwd ) -> cf_sem:fut()
-when App    :: cf_sem:app(),
-     Cwd    :: string(),
-     Runtime :: atom() | pid().
+when Runtime :: atom() | pid(),
+     App    :: cf_sem:app(),
+     Cwd    :: string().
 
 submit( Runtime, App, Cwd )
-when is_tuple( App ), is_list( Cwd ) ->
+when is_pid( Runtime ) orelse is_atom( Runtime ), is_tuple( App ), is_list( Cwd ) ->
   gen_server:call( Runtime, {submit, App, Cwd} ).
 
 %% =============================================================================
@@ -263,7 +263,7 @@ when is_tuple( App ), is_list( Cwd ) ->
 %% =============================================================================
 
 stage( Runtime, Lam, Fa, DataDir, Mod, R, LibMap, ModState )
-when is_pid( Runtime); is_atom( Runtime ),
+when is_pid( Runtime ) orelse is_atom( Runtime ),
      is_tuple( Lam ),
      is_map( Fa ),
      is_list( DataDir ),

--- a/src/cf_cre.erl
+++ b/src/cf_cre.erl
@@ -37,7 +37,7 @@
 %% Function Exports
 %% =============================================================================
 
--export( [start_link/3, submit/2] ).
+-export( [start_link/3, submit/3] ).
 
 -export( [code_change/3, handle_cast/2, handle_info/2, init/1, terminate/2,
           handle_call/3] ).
@@ -162,7 +162,8 @@ when is_tuple( App ),
     false ->
 
       % start process
-      _Pid = spawn_link( fun() -> stage( Lam, Fa, DataDir, Mod, R, LibMap, ModState ) end ),
+      Runtime = self(),
+      _Pid = spawn_link( fun() -> stage( Runtime, Lam, Fa, DataDir, Mod, R, LibMap, ModState ) end ),
 
       % create new future
       Fut = {fut, LamName, R, Lo},
@@ -248,28 +249,30 @@ when is_atom( Mod ), is_map( LibMap ) ->
   gen_server:start_link( {local, cre}, ?MODULE, {Mod, ModArg, LibMap}, [] ).
 
 
--spec submit( App, Cwd ) -> cf_sem:fut()
+-spec submit( Runtime, App, Cwd ) -> cf_sem:fut()
 when App    :: cf_sem:app(),
-     Cwd    :: string().
+     Cwd    :: string(),
+     Runtime :: atom() | pid().
 
-submit( App, Cwd )
+submit( Runtime, App, Cwd )
 when is_tuple( App ), is_list( Cwd ) ->
-  gen_server:call( cre, {submit, App, Cwd} ).
+  gen_server:call( Runtime, {submit, App, Cwd} ).
 
 %% =============================================================================
 %% Internal Functions
 %% =============================================================================
 
-stage( Lam, Fa, DataDir, Mod, R, LibMap, ModState )
-when is_tuple( Lam ),
+stage( Runtime, Lam, Fa, DataDir, Mod, R, LibMap, ModState )
+when is_pid( Runtime); is_atom( Runtime ),
+     is_tuple( Lam ),
      is_map( Fa ),
      is_list( DataDir ),
-     is_atom( Mod ),     
+     is_atom( Mod ),
      is_integer( R ), R > 0,
      is_map( LibMap ) ->
 
   Reply = apply( Mod, handle_submit, [Lam, Fa, DataDir, R, LibMap, ModState] ),
-  cre ! Reply.
+  Runtime ! Reply.
 
 
 -ifdef( TEST ).

--- a/src/cf_shell.erl
+++ b/src/cf_shell.erl
@@ -83,7 +83,7 @@ server_loop( Rho, Gamma, Cwd ) ->
       case Query of
         undef -> server_loop( Rho1, Gamma1, Cwd );
         _     ->
-          try cuneiform:reduce( Query, Rho1, Gamma1, "." ) of
+          try cuneiform:reduce( cre, Query, Rho1, Gamma1, "." ) of
             X -> io:format( "~s~n", [cuneiform:format_result( X )] )
           catch
             throw:T -> io:format( "~s~n", [cuneiform:format_error( T )] )
@@ -162,5 +162,3 @@ get_banner() ->
      "  @N____ 3@B         "++?BLU( "http://www.cuneiform-lang.org" ),
      "  \"W@@@WF3@B"
     ], "\n" ).
-
-

--- a/src/cuneiform.erl
+++ b/src/cuneiform.erl
@@ -24,7 +24,7 @@
 -vsn( "2.2.1-snapshot" ).
 
 % API
--export( [main/1, file/2, start/3, reduce/4, get_vsn/0, format_result/1, format_error/1] ).
+-export( [main/1, file/2, start/3, reduce/5, get_vsn/0, format_result/1, format_error/1] ).
 
 
 -include( "cuneiform.hrl" ).
@@ -76,7 +76,7 @@ file( File, Cwd ) ->
     {error, ErrorInfo}        ->
       {error, ErrorInfo};
     {ok, {Query, Rho, Gamma}} ->
-      try cuneiform:reduce( Query, Rho, Gamma, Cwd ) of
+      try cuneiform:reduce( cre, Query, Rho, Gamma, Cwd ) of
         X -> {ok, X}
       catch
         throw:T -> {error, T}
@@ -104,14 +104,15 @@ get_libmap( OptLst ) ->
 
 %% Reduction %%
 
--spec reduce( X0, Rho, Gamma, Cwd ) -> [cf_sem:str()]
-when X0     :: [cf_sem:expr()],
+-spec reduce( Runtime, X0, Rho, Gamma, Cwd ) -> [cf_sem:str()]
+when Runtime :: atom() | pid(),
+     X0     :: [cf_sem:expr()],
      Rho    :: #{string() => [cf_sem:expr()]},
      Gamma  :: #{string() => cf_sem:lam()},
      Cwd    :: string().
 
-reduce( X0, Rho, Gamma, Cwd ) ->
-  Mu = fun( A ) -> cf_cre:submit( A, Cwd ) end,
+reduce( Runtime, X0, Rho, Gamma, Cwd ) ->
+  Mu = fun( A ) -> cf_cre:submit( Runtime, A, Cwd ) end,
   reduce( X0, {Rho, Mu, Gamma, #{}}, Cwd ).
 
 -spec reduce( X0, Theta, Cwd ) -> [cf_sem:str()]
@@ -130,7 +131,7 @@ reduce( X0, {Rho, Mu, Gamma, Omega}, Cwd ) ->
         {failed, R2, R, Data} ->
           {AppLine, LamName} = hd( find_select( R, X1 ) ),
           throw( {AppLine, cuneiform, {R2, LamName, R, Data}} );
-          
+
 
         {finished, Summary} ->
           Ret = maps:get( ret, Summary ),

--- a/src/lib_conf.erl
+++ b/src/lib_conf.erl
@@ -1,0 +1,48 @@
+%% -*- erlang -*-
+%%
+%% Cuneiform: A Functional Language for Large Scale Scientific Data Analysis
+%%
+%% Copyright 2016 Jörgen Brandt, Marc Bux, and Ulf Leser
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%    http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% @author Jörgen Brandt <brandjoe@hu-berlin.de>
+
+-module( lib_conf ).
+-author( "Jorgen Brandt <brandjoe@hu-berlin.de>" ).
+-vsn( "2.2.1-snapshot" ).
+
+-export( [create_conf/3] ).
+
+-spec create_conf( DefaultMap, ConfFile, ManualMap ) -> #{}
+when DefaultMap :: #{},
+     ConfFile   :: string(),
+     ManualMap  :: #{}.
+
+create_conf( DefaultMap, ConfFile, ManualMap )
+when is_map( DefaultMap ),
+     is_list( ConfFile ),
+     is_map( ManualMap ) ->
+
+  case file:read_file( ConfFile ) of
+    {error, enoent} -> DefaultMap;
+    {error, Reason1} -> error( {Reason1, ConfFile} );
+    {ok, B}         ->
+      S = binary_to_list( B ),
+      {ok, Tokens, _} = erl_scan:string( S ),
+      ConfMap = case erl_parse:parse_term( Tokens ) of
+        {error, Reason2} -> error( Reason2 );
+        {ok, Y}         -> Y
+      end,
+      maps:merge( DefaultMap, maps:merge( ConfMap, ManualMap ) )
+  end.


### PR DESCRIPTION
- explicit mention of Pid or Atom as reduce/5 argument to allow
  3rd party interpreters to choose their own runtime Pid
- cf_cre:submit/3 mention Pid or Atom as 1st argument
